### PR TITLE
Fix: changing OverlayModel in canonical dialect to Overlay to match iri in AMF Model

### DIFF
--- a/exporters/src/main/scala/amf/exporters/CanonicalWebAPISpecDialectExporter.scala
+++ b/exporters/src/main/scala/amf/exporters/CanonicalWebAPISpecDialectExporter.scala
@@ -417,7 +417,7 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = new ConsoleLogger()) {
       |      Library: Module
       |      Document: Document
       |      Extension: Extension
-      |      Overlay: OverlayModel
+      |      Overlay: Overlay
       |    union:
       |      - DataTypeFragment
       |      - DocumentationItemFragment
@@ -428,7 +428,7 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = new ConsoleLogger()) {
       |      - Module
       |      - Document
       |      - Extension
-      |      - OverlayModel
+      |      - Overlay
       |""".stripMargin
 
   def renderDialect(): String = {

--- a/vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml
+++ b/vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml
@@ -144,7 +144,7 @@ nodeMappings:
       Library: Module
       Document: Document
       Extension: Extension
-      Overlay: OverlayModel
+      Overlay: Overlay
     union:
       - DataTypeFragment
       - DocumentationItemFragment
@@ -155,7 +155,7 @@ nodeMappings:
       - Module
       - Document
       - Extension
-      - OverlayModel
+      - Overlay
 
   APIKeySettings:
     classTerm: security.ApiKeySettings
@@ -1373,7 +1373,7 @@ nodeMappings:
         allowMultiple: true
 
 
-  OverlayModel:
+  Overlay:
     classTerm: apiContract.Overlay
     extends: Document
 

--- a/vocabulary/src/main/resources/vocabularies/api_contract.yaml
+++ b/vocabulary/src/main/resources/vocabularies/api_contract.yaml
@@ -53,7 +53,7 @@ classTerms:
     displayName: Operation
     description: Action that can be executed using a particular HTTP invocation
   Overlay:
-    displayName: Overlay Model
+    displayName: Overlay
     description: Model defining a RAML overlay
     extends:
       - doc.Document


### PR DESCRIPTION
Context: in AMF's meta-model the "OverlayModel" has iri "apiContract:Overlay" while in the ModelDoc it has the name "Overlay Model". When the canonical webapi dialect is produced the "Overlay" node mapping will have name "OverlayModel" instead of "Overlay". When comparing iris() in the baseUnit mapping of the CanonicalTransform the "Overlay" entity isn't found because iris don't match.

One is: "apiContract:Overlay" while the other one is "apiContract:OverlayModel".

Note: this commit won't pass until a fix in the AMF model docs is changed.
Note 2: "OverlayModel" seems to be the only node mapping that has the "Model" suffix. It's most similar entity "Extension" doesn't have the "Model" suffix
Note 3: this doesn't impact in the JSON-LD resultant model as it isn't aware of "Extensions" or "Overlays". It is just aware of the underlying "Document" type.