### PR TITLE
APIMF-2397: added Async binding unions to correctly validate dialects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,8 @@ val commonSettings = Common.settings ++ Common.publish ++ Seq(
   organization := "com.github.amlorg",
   resolvers ++= List(ivyLocal, Common.releases, Common.snapshots, Resolver.mavenLocal),
   resolvers += "jitpack" at "https://jitpack.io",
-  credentials ++= Common.credentials()
+  credentials ++= Common.credentials(),
+  logBuffered in Test := false
 )
 
 lazy val dependencies = new {

--- a/exporters/src/main/scala/amf/exporters/CanonicalWebAPISpecDialectExporter.scala
+++ b/exporters/src/main/scala/amf/exporters/CanonicalWebAPISpecDialectExporter.scala
@@ -416,6 +416,68 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = new ConsoleLogger()) {
       |      - Overlay
       |""".stripMargin
 
+  val channelBindingUnionDeclaration: String = "ChannelBindingUnion"
+  val channelBindingUnion: String =
+  s"""  $channelBindingUnionDeclaration:
+    |    typeDiscriminatorName: bindingType
+    |    typeDiscriminator:
+    |      WebSockets: WebSocketsChannelBinding
+    |      Amqp091: Amqp091ChannelBinding
+    |      Empty: EmptyBinding
+    |    union:
+    |      - WebSocketsChannelBinding
+    |      - Amqp091ChannelBinding
+    |      - EmptyBinding
+    |""".stripMargin
+
+  val serverBindingUnionDeclaration: String = "ServerBindingUnion"
+  val serverBindingUnion: String =
+    s"""  $serverBindingUnionDeclaration:
+       |    typeDiscriminatorName: bindingType
+       |    typeDiscriminator:
+       |      Mqtt: MqttServerBinding
+       |      Empty: EmptyBinding
+       |    union:
+       |      - MqttServerBinding
+       |      - EmptyBinding
+       |""".stripMargin
+
+  val operationBindingUnionDeclaration: String = "OperationBindingUnion"
+  val operationBindingUnion: String =
+    s"""  $operationBindingUnionDeclaration:
+       |    typeDiscriminatorName: bindingType
+       |    typeDiscriminator:
+       |      Amqp091: Amqp091OperationBinding
+       |      Mqtt: MqttOperationBinding
+       |      Http: HttpOperationBinding
+       |      Kafka: KafkaOperationBinding
+       |      Empty: EmptyBinding
+       |    union:
+       |      - Amqp091OperationBinding
+       |      - MqttOperationBinding
+       |      - HttpOperationBinding
+       |      - KafkaOperationBinding
+       |      - EmptyBinding
+       |""".stripMargin
+
+  val messageBindingUnionDeclaration: String = "MessageBindingUnion"
+  val messageBindingUnion: String =
+    s"""  $messageBindingUnionDeclaration:
+       |    typeDiscriminatorName: bindingType
+       |    typeDiscriminator:
+       |      Amqp091: Amqp091MessageBinding
+       |      Mqtt: MqttMessageBinding
+       |      Http: HttpMessageBinding
+       |      Kafka: KafkaMessageBinding
+       |      Empty: EmptyBinding
+       |    union:
+       |      - Amqp091MessageBinding
+       |      - MqttMessageBinding
+       |      - HttpMessageBinding
+       |      - KafkaMessageBinding
+       |      - EmptyBinding
+       |""".stripMargin
+
   def renderDialect(): String = {
     val stringBuilder                              = new StringBuilder()
     val externals: mutable.HashMap[String, String] = mutable.HashMap()
@@ -443,6 +505,15 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = new ConsoleLogger()) {
 
     // Parsed unit union
     stringBuilder.append(parsedUnitUnion + "\n")
+
+    // Channel binding union
+    stringBuilder.append(channelBindingUnion + "\n")
+    // Server binding union
+    stringBuilder.append(serverBindingUnion + "\n")
+    // Message binding union
+    stringBuilder.append(messageBindingUnion + "\n")
+    // Operation binding union
+    stringBuilder.append(operationBindingUnion + "\n")
 
     val orderedNodeMappings = nodeMappings.values.toSeq.sortBy(_.name).map(_.id)
     orderedNodeMappings.foreach { nodeMappingId =>
@@ -516,6 +587,14 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = new ConsoleLogger()) {
                   stringBuilder.append(s"        range: $parsedUnitUnionDeclaration\n")
                 } else if (propertyMapping.range == "DataNode") {
                   stringBuilder.append(s"        range: $dataNodeUnionDeclaration\n")
+                } else if (propertyMapping.range == "ChannelBinding") {
+                  stringBuilder.append(s"        range: $channelBindingUnionDeclaration\n")
+                } else if (propertyMapping.range == "ServerBinding") {
+                  stringBuilder.append(s"        range: $serverBindingUnionDeclaration\n")
+                } else if (propertyMapping.range == "MessageBinding") {
+                  stringBuilder.append(s"        range: $messageBindingUnionDeclaration\n")
+                } else if (propertyMapping.range == "OperationBinding") {
+                  stringBuilder.append(s"        range: $operationBindingUnionDeclaration\n")
                 } else if (propertyMapping.range == "uri") {
                   stringBuilder.append(s"        range: link\n")
                 } else {

--- a/transform/src/test/resources/transformations/message-bindings/api.yaml
+++ b/transform/src/test/resources/transformations/message-bindings/api.yaml
@@ -1,0 +1,16 @@
+asyncapi: '2.0.0'
+info:
+  title: Amqp message binding
+  version: '1.0.0'
+
+channels:
+  some-channel:
+    publish:
+      message:
+        bindings:
+          amqp:
+            bindingVersion: 31.07.92
+            messageType: sometype
+            contentEncoding: some/mime
+          kafka:
+            key: somekey

--- a/transform/src/test/resources/transformations/message-bindings/webapi.json
+++ b/transform/src/test/resources/transformations/message-bindings/webapi.json
@@ -1,0 +1,189 @@
+[
+  {
+    "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#DialectInstance",
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/meta#definedBy": [
+      {
+        "@id": "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/rootAsset",
+        "@type": [
+          "http://a.ml/vocabularies/document#Document",
+          "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/Document",
+          "http://a.ml/vocabularies/meta#DialectDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": true
+          }
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#WebAPI",
+              "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/WebAPI",
+              "http://a.ml/vocabularies/meta#DialectDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "Amqp message binding"
+              }
+            ],
+            "http://a.ml/vocabularies/core#version": [
+              {
+                "@value": "1.0.0"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#endpoint": [
+              {
+                "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#EndPoint",
+                  "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/EndPoint",
+                  "http://a.ml/vocabularies/meta#DialectDomainElement",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#supportedOperation": [
+                  {
+                    "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Operation",
+                      "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/Operation",
+                      "http://a.ml/vocabularies/meta#DialectDomainElement",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/apiContract#expects": [
+                      {
+                        "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request",
+                        "@type": [
+                          "http://a.ml/vocabularies/apiContract#Request",
+                          "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/Request",
+                          "http://a.ml/vocabularies/meta#DialectDomainElement",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/apiContract#payload": [
+                          {
+                            "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/default",
+                            "@type": [
+                              "http://a.ml/vocabularies/apiContract#Payload",
+                              "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/Payload",
+                              "http://a.ml/vocabularies/meta#DialectDomainElement",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/apiBinding#binding": [
+                          {
+                            "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/message-bindings",
+                            "@type": [
+                              "http://a.ml/vocabularies/apiBinding#MessageBindings",
+                              "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/MessageBindings",
+                              "http://a.ml/vocabularies/meta#DialectDomainElement",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/apiBinding#binding": [
+                              {
+                                "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/message-bindings/kafka-message",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiBinding#KafkaMessageBinding",
+                                  "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/KafkaMessageBinding",
+                                  "http://a.ml/vocabularies/meta#DialectDomainElement",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#type": [
+                                  {
+                                    "@value": "kafka"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#messageKey": [
+                                  {
+                                    "@value": "somekey"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#bindingVersion": [
+                                  {
+                                    "@value": "latest"
+                                  }
+                                ]
+                              },
+                              {
+                                "@id": "file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/message-bindings/amqp091-message",
+                                "@type": [
+                                  "http://a.ml/vocabularies/apiBinding#Amqp091MessageBinding",
+                                  "file://vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml#/declarations/Amqp091MessageBinding",
+                                  "http://a.ml/vocabularies/meta#DialectDomainElement",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#type": [
+                                  {
+                                    "@value": "amqp"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#messageType": [
+                                  {
+                                    "@value": "sometype"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#contentEncoding": [
+                                  {
+                                    "@value": "some/mime"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/apiBinding#bindingVersion": [
+                                  {
+                                    "@value": "31.07.92"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/apiContract#method": [
+                      {
+                        "@value": "publish"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#path": [
+                  {
+                    "@value": "some-channel"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#version": [
+          {
+            "@value": "2.1.0"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "2.1.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": false
+      }
+    ]
+  }
+]

--- a/transform/src/test/resources/transformations/message-bindings/webapi.yaml
+++ b/transform/src/test/resources/transformations/message-bindings/webapi.yaml
@@ -1,0 +1,40 @@
+#%WebAPI Spec 1.0
+unitType: Document
+$id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/rootAsset
+version: 2.1.0
+root: true
+encodes:
+  elementType: WebAPI
+  $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api
+  name: Amqp message binding
+  version: 1.0.0
+  endpoint:
+    -
+      $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel
+      supportedOperation:
+        -
+          $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish
+          expects:
+            -
+              $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request
+              binding:
+                $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/message-bindings
+                binding:
+                  -
+                    bindingType: Kafka
+                    $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/message-bindings/kafka-message
+                    key: somekey
+                    bindingVersion: latest
+                    type: kafka
+                  -
+                    bindingType: Amqp091
+                    $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/message-bindings/amqp091-message
+                    contentEncoding: some/mime
+                    bindingVersion: 31.07.92
+                    type: amqp
+                    messageType: sometype
+              payload:
+                -
+                  $id: file://transform/src/test/resources/transformations/message-bindings/api.yaml#/web-api/end-points/some-channel/publish/request/default
+          method: publish
+      path: some-channel

--- a/transform/src/test/scala/amf/transform/canonical/AsyncCanonicalValidationTest.scala
+++ b/transform/src/test/scala/amf/transform/canonical/AsyncCanonicalValidationTest.scala
@@ -9,17 +9,6 @@ class AsyncCanonicalValidationTest extends CanonicalSpecValidationTest {
 
 
   override val ignoredApis: Set[String] = Set(
-    "kafka-operation-binding.yaml",
-    "rpc-server.yaml",
-    "http-message-binding.yaml",
-    "empty-dynamic-binding.yaml",
-    "amqp-message-binding.yaml",
-    "mqtt-message-binding.yaml",
-    "kafka-message-binding.yaml",
-    "mqtt-server-binding.yaml",
-    "amqp-operation-binding.yaml",
-    "components/external-operation-traits.yaml",
-    "components/async-components.yaml",
     "components/operation-traits.yaml"
   )
   override val apiPaths = Set(
@@ -43,7 +32,7 @@ class AsyncCanonicalValidationTest extends CanonicalSpecValidationTest {
     "security-schemes.yaml",
     "ws-channel-binding.yaml",
     "components/async-components.yaml",
-    "components/external-operation-traits.yaml",
+//    "components/external-operation-traits.yaml",
     "components/message-traits.yaml",
     "components/operation-traits.yaml"
   )

--- a/transform/src/test/scala/amf/transform/canonical/E2ECanonicalWebApiDialectTest.scala
+++ b/transform/src/test/scala/amf/transform/canonical/E2ECanonicalWebApiDialectTest.scala
@@ -35,8 +35,12 @@ class E2ECanonicalWebApiDialectTest extends FunSuiteCycleTests with CanonicalTra
   tests.foreach { input =>
     val golden = input.replace("api.raml", "webapi")
     test(s"Test '$input' for WebAPI dialect transformation and yaml/json rendering") {
-      checkCanonicalDialectTransformation(input, golden, shouldTransform = false)
+      checkCanonicalDialectTransformation(input, golden)
     }
+  }
+
+  test("Test that dialect instance with bindings has correct discriminator") {
+    checkCanonicalDialectTransformation("message-bindings/api.yaml", "message-bindings/webapi", AsyncYamlHint)
   }
 
   test("Test that canonical transformer only accepts Documents") {
@@ -54,15 +58,13 @@ class E2ECanonicalWebApiDialectTest extends FunSuiteCycleTests with CanonicalTra
       AMF.init().flatMap(_ => canonicalTransform(s"${basePath}simple/api.raml", RamlYamlHint, UnregisterDialectRegistration())))
   }
 
-  def checkCanonicalDialectTransformation(source: String,
-                                          target: String,
-                                          shouldTransform: Boolean): Future[Assertion] = {
+  def checkCanonicalDialectTransformation(source: String, target: String, hint: Hint = RamlYamlHint): Future[Assertion] = {
     val amfWebApi  = basePath + source
     val goldenYaml = s"$basePath$target.yaml"
     val goldenJson = s"$basePath$target.json"
 
     for {
-      transformed <- canonicalTransform(amfWebApi)
+      transformed <- canonicalTransform(amfWebApi, hint)
       yamlDiffOk <- diff(goldenYaml) { () =>
         new AMFRenderer(transformed, Vendor.AML, RenderOptions().withNodeIds, Some(Syntax.Yaml)).renderToString
       }

--- a/vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml
+++ b/vocabulary/src/main/resources/dialects/canonical_webapi_spec.yaml
@@ -157,6 +157,56 @@ nodeMappings:
       - Extension
       - Overlay
 
+  ChannelBindingUnion:
+    typeDiscriminatorName: bindingType
+    typeDiscriminator:
+      WebSockets: WebSocketsChannelBinding
+      Amqp091: Amqp091ChannelBinding
+      Empty: EmptyBinding
+    union:
+      - WebSocketsChannelBinding
+      - Amqp091ChannelBinding
+      - EmptyBinding
+
+  ServerBindingUnion:
+    typeDiscriminatorName: bindingType
+    typeDiscriminator:
+      Mqtt: MqttServerBinding
+      Empty: EmptyBinding
+    union:
+      - MqttServerBinding
+      - EmptyBinding
+
+  MessageBindingUnion:
+    typeDiscriminatorName: bindingType
+    typeDiscriminator:
+      Amqp091: Amqp091MessageBinding
+      Mqtt: MqttMessageBinding
+      Http: HttpMessageBinding
+      Kafka: KafkaMessageBinding
+      Empty: EmptyBinding
+    union:
+      - Amqp091MessageBinding
+      - MqttMessageBinding
+      - HttpMessageBinding
+      - KafkaMessageBinding
+      - EmptyBinding
+
+  OperationBindingUnion:
+    typeDiscriminatorName: bindingType
+    typeDiscriminator:
+      Amqp091: Amqp091OperationBinding
+      Mqtt: MqttOperationBinding
+      Http: HttpOperationBinding
+      Kafka: KafkaOperationBinding
+      Empty: EmptyBinding
+    union:
+      - Amqp091OperationBinding
+      - MqttOperationBinding
+      - HttpOperationBinding
+      - KafkaOperationBinding
+      - EmptyBinding
+
   APIKeySettings:
     classTerm: security.ApiKeySettings
     extends: Settings
@@ -442,7 +492,7 @@ nodeMappings:
         range: string
       binding:
         propertyTerm: apiBinding.binding
-        range: ChannelBinding
+        range: ChannelBindingUnion
         allowMultiple: true
       designLink:
         propertyTerm: doc.design-link-target
@@ -1011,7 +1061,7 @@ nodeMappings:
         range: string
       binding:
         propertyTerm: apiBinding.binding
-        range: MessageBinding
+        range: MessageBindingUnion
         allowMultiple: true
       designLink:
         propertyTerm: doc.design-link-target
@@ -1332,7 +1382,7 @@ nodeMappings:
         range: string
       binding:
         propertyTerm: apiBinding.binding
-        range: OperationBinding
+        range: OperationBindingUnion
         allowMultiple: true
       designLink:
         propertyTerm: doc.design-link-target
@@ -1799,7 +1849,7 @@ nodeMappings:
         range: string
       binding:
         propertyTerm: apiBinding.binding
-        range: ServerBinding
+        range: ServerBindingUnion
         allowMultiple: true
       designLink:
         propertyTerm: doc.design-link-target


### PR DESCRIPTION
Question: should these abstract bindings (ChannelBinding, ServerBinding...) be **blacklisted** supertypes? They are not creatable in the model.

Resolved: No. We only have to keep it from being in a nodeMappings range
