### PR TITLE
Adopt AMF 4.7.5

### DIFF
--- a/transform/dependencies.properties
+++ b/transform/dependencies.properties
@@ -1,3 +1,3 @@
 # Leave here for the publication process to detect if amf-transform has to be published!
 # Because we publish a version of amf-transform for each version of amf-client publish.
-amf.client=4.8.0-SNAPSHOT
+amf.client=4.7.5

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,2 +1,2 @@
-amf.vocabulary: 11.1.0-SNAPSHOT
-amf.transform: 1.12.0-SNAPSHOT
+amf.vocabulary: 12.0.0
+amf.transform: 1.12


### PR DESCRIPTION
publish `amf.vocabulary 12.0.0` and `amf.transform 1.12` that adopt amf version 4.7.5
