### PR TITLE
APIMF-3319: exclude BaseUnitSourceInformation and LocationInformation nodes from canonical transformation

### DIFF
--- a/exporters/src/main/scala/amf/exporters/CanonicalWebAPISpecDialectExporter.scala
+++ b/exporters/src/main/scala/amf/exporters/CanonicalWebAPISpecDialectExporter.scala
@@ -197,7 +197,8 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = ConsoleLogger) {
     (Namespace.Document + "recursive").iri(),
     (Namespace.Document + "extends").iri(),
     DomainElementModel.CustomDomainProperties.value.iri(),
-    BaseUnitModel.ProcessingData.value.iri()
+    BaseUnitModel.ProcessingData.value.iri(),
+    BaseUnitModel.SourceInformation.value.iri()
   )
 
   val blocklistedSupertypes: Set[String] = Set(
@@ -217,7 +218,9 @@ class CanonicalWebAPISpecDialectExporter(logger: Logger = ConsoleLogger) {
     "DomainElement",
     "SourceMap",
     "APIContractProcessingData",
-    "BaseUnitProcessingData"
+    "BaseUnitProcessingData",
+    "BaseUnitSourceInformation",
+    "LocationInformation"
   )
 
   val shapeUnionDeclaration = "DataShapesUnion"

--- a/exporters/src/main/scala/amf/exporters/VocabularyExporter.scala
+++ b/exporters/src/main/scala/amf/exporters/VocabularyExporter.scala
@@ -6,7 +6,7 @@ import amf.core.client.scala.vocabulary.Namespace
 
 import java.io.{File, FileWriter, Writer}
 import amf.core.internal.metamodel.Type.{Bool, Date, DateTime, Double, EncodedIri, Float, Int, Iri, RegExp, Str, Time}
-import amf.core.internal.metamodel.document.{BaseUnitModel, BaseUnitProcessingDataModel}
+import amf.core.internal.metamodel.document.{BaseUnitModel, BaseUnitProcessingDataModel, BaseUnitSourceInformationModel, LocationInformationModel}
 import amf.core.internal.metamodel.domain._
 import amf.core.internal.metamodel.{Field, Obj, Type}
 import amf.transform.internal.canonical.CanonicalWebAPISpecExtraModel
@@ -116,13 +116,19 @@ object VocabularyExporter {
     (Namespace.Document + "APIContractProcessingData").iri(),
     (Namespace.Document + "DialectInstanceProcessingData").iri(),
     (Namespace.Document + "BaseUnitProcessingData").iri(),
+    (Namespace.Document + "BaseUnitSourceInformation").iri(),
+    (Namespace.Document + "LocationInformation").iri(),
   )
 
   val blockedProperties: Seq[String] = Seq(
     BaseUnitModel.ProcessingData.value.iri(),
     BaseUnitProcessingDataModel.Transformed.value.iri(),
     APIContractProcessingDataModel.SourceSpec.value.iri(),
-    APIContractProcessingDataModel.APIContractModelVersion.value.iri()
+    APIContractProcessingDataModel.APIContractModelVersion.value.iri(),
+    BaseUnitModel.SourceInformation.value.iri(),
+    BaseUnitSourceInformationModel.AdditionalLocations.value.iri(),
+    BaseUnitSourceInformationModel.RootLocation.value.iri(),
+    LocationInformationModel.Elements.value.iri()
   )
 
   val blocklist: Map[ModelVocabulary, Seq[ModelVocabulary]] = Map()

--- a/transform/src/main/scala/amf/transform/internal/canonical/CanonicalWebAPISpecTransformer.scala
+++ b/transform/src/main/scala/amf/transform/internal/canonical/CanonicalWebAPISpecTransformer.scala
@@ -232,7 +232,7 @@ private[amf] object CanonicalWebAPISpecTransformer extends PlatformSecrets with 
 
   private def createConfigOnlyWithDialectEntities(config: AMLConfiguration, dialect: Dialect) = {
     val modelIds = dialect.declares.collect { case n: NodeMapping => n.id }
-    val entities = config.registry.entitiesRegistry.domainEntities
+    val entities = config.registry.getEntitiesRegistry.domainEntities
     val dialectEntities = modelIds.foldLeft(Map[String, ModelDefaultBuilder]()) { (acc, curr) => acc + (curr -> entities(curr)) }
     val nextConfig = AMLConfiguration.empty().withEntities(dialectEntities ++ AMLEntities.entities)
     nextConfig

--- a/transform/src/test/scala/amf/transform/internal/canonical/E2ECanonicalWebApiDialectTest.scala
+++ b/transform/src/test/scala/amf/transform/internal/canonical/E2ECanonicalWebApiDialectTest.scala
@@ -88,7 +88,7 @@ class E2ECanonicalWebApiDialectTest extends FunSuiteCycleTests with CanonicalTra
       transformed.sourceSpec shouldBe Some(AmlDialectSpec("WebAPI Spec 1.0"))
       val profileFromSpec = transformed.sourceSpec.map(spec => ProfileName(spec.id)).get
       // TODO: This should be tested in a more black box way. Improve
-      config.registry.constraintsRules.contains(profileFromSpec) shouldBe true
+      config.registry.getConstraintsRules.contains(profileFromSpec) shouldBe true
     }
   }
 

--- a/vocabulary/src/main/resources/vocabularies/aml_doc.yaml
+++ b/vocabulary/src/main/resources/vocabularies/aml_doc.yaml
@@ -141,7 +141,7 @@ propertyTerms:
     range: uri
   location:
     displayName: location
-    description: Location of an inlined fragment
+    description: Location of the metadata document that generated this base unit
     range: string
   package:
     displayName: package


### PR DESCRIPTION
Merge into develop when we have 5.1.0-SNAPSHOT publishing correctly.