### PR TITLE
W-12368914: publish amf.vocabulary 34.0.0 & amf.transform 2.18.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
                 anyOf {
                     branch 'master'
                     branch 'develop'
+                    branch 'release/*'
                 }
             }
             steps {
@@ -80,6 +81,7 @@ pipeline {
                 anyOf {
                     branch 'master'
                     branch 'develop'
+                    branch 'release/*'
                 }
             }
             steps {

--- a/transform/dependencies.properties
+++ b/transform/dependencies.properties
@@ -1,4 +1,4 @@
 # Leave here for the publication process to detect if amf-transform has to be published!
 # Because we publish a version of amf-transform for each version of amf-client publish.
-amf.apicontract=5.3.0-SNAPSHOT
-amf.rdf=6.3.0-SNAPSHOT
+amf.apicontract=5.2.5-RC.0
+amf.rdf=6.2.5-RC.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,2 +1,2 @@
-amf.vocabulary: 33.1.0-SNAPSHOT
-amf.transform: 2.18.0-SNAPSHOT
+amf.vocabulary: 34.0.0-RC.0
+amf.transform: 2.18.0-RC.0


### PR DESCRIPTION
- Publish 33.1.0-SNAPSHOT and 2.18.0-SNAPSHOT
- publish vocabulary and transform RCs adopting amf 5.2.5-RC.0
- setup amf.vocabulary 34.0.0 & amf.transform 2.18.0
- adopt release versions in transform/dependencies
