### PR TITLE
W-13191540: bump to ScalaJS 1.6 & Scala 2.12.15 & SBT 1.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.1
+FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.2

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Versions.versions
 
 name := "amf-metadata"
 ThisBuild / organization := "com.github.amlorg"
-ThisBuild / scalaVersion := "2.12.13"
+ThisBuild / scalaVersion := "2.12.15"
 
 val artifactVersions = new {
   val vocabularyVersion = versions("versions.yaml")("amf.vocabulary")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.3


### PR DESCRIPTION
- bump sbt version to 1.7.3
- bump scala version to 2.12.15
- bump amf-ci-tools to 1.3.2
